### PR TITLE
🐛 : Improve URL matching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,11 +12,11 @@
   "content_scripts": [
     {
       "js": ["src/content/studyTable.js"],
-      "matches": ["https://www.reg.kmitl.ac.th/u_student/report_studytable_show.php"]
+      "matches": ["https://*.reg.kmitl.ac.th/u_student/report_studytable_show.php"]
     },
     {
       "js": ["src/content/examSchedule.js"],
-      "matches": ["https://www.reg.kmitl.ac.th/u_student/report_examtable_show.php"]
+      "matches": ["https://*.reg.kmitl.ac.th/u_student/report_examtable_show.php"]
     }
   ]
 }


### PR DESCRIPTION
## What happened?
URL Matching with `https://www.reg.kmitl.ac.th` does not work on my machine since the url is only `https://reg.kmitl.ac.th`.

## What did I improve?
Improved matching by replacing `https://www.reg.kmitl.ac.th` with a wildcard `https://*.reg.kmitl.ac.th`. so it "SHOULD" work with both for url beginning with `https://www.reg.kmitl.ac.th` AND `https://reg.kmitl.ac.th`.